### PR TITLE
docs: add scope disclaimers and update README for M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,28 +16,42 @@ lessons learned from that attempt.
 
 ## Status
 
-**Tier 3 design phase** — all architecture and design artifacts are being
-produced before any implementation code is written.
+**Design phase complete (M1–M3).** Next milestone: M4 (Specification) —
+technical specs and schema definitions.
 
-See `PLANS.md` for current progress and `docs/` for design artifacts.
+- M1 (Planning): intake, proposal, PRD, charter, roadmap, backlog
+- M2 (Architecture): 2 options analyses, 12 ADRs
+- M3 (Design): system design v0.1.3, 4 module designs, SLI/SLO, risk
+  register. Design review 45/45 PASS.
+
+See [PLANS.md](PLANS.md) for session history and
+[docs/](docs/) for all artifacts.
 
 ## Architecture overview
 
-(Design in progress — see `docs/design/system-design.md` when available)
+See [system design v0.1.3](docs/design/system-design.md) for the full
+architecture. Core concepts:
 
-Core concepts:
-
-- **Memory Kernel**: Typed records (Decision, Belief, Episode, Skill) with
-  temporal awareness and versioning
-- **Agentic Retrieval**: 6-stage pipeline with hybrid search, validation,
-  and bounded retries
-- **Librarian Gate**: No durable memory write without policy authorization
+- **Memory Kernel**: 8 typed records (Belief, Decision, Entity, Episode,
+  Preference, Reflection, Resource, Skill) with temporal awareness and
+  versioning
+- **HippoRAG Retrieval**: 6-stage pipeline with adaptive routing, hybrid
+  search, validation, and bounded retries
+  ([ADR-011](docs/architecture/adr/ADR-011-hipporag-retrieval.md))
+- **Librarian Gate**: No durable memory write without policy authorization —
+  hybrid declarative rules + RL-trained advisor
+  ([ADR-012](docs/architecture/adr/ADR-012-hybrid-librarian-gate.md))
 - **Dual Protocol**: MCP (agent-to-tools) + A2A v0.3 (agent-to-agent)
+  ([ADR-002](docs/architecture/adr/ADR-002-dual-protocol.md))
 - **Monolith-first**: Single Python service with clear module boundaries
+  ([ADR-001](docs/architecture/adr/ADR-001-monolith-first.md))
+- **Postgres+pgvector**: Unified storage
+  ([ADR-003](docs/architecture/adr/ADR-003-storage-backend.md))
+- **Self-healing**: Circuit breakers + retries at module boundaries
 
 ## Quick start
 
-Prerequisites and setup instructions will be added after the design
+Prerequisites and setup instructions will be added after the specification
 phase completes.
 
 ## Development workflow
@@ -52,8 +66,33 @@ Testing strategy and commands will be added after specification phase.
 
 ## Documentation
 
+### Planning (M1)
+
 - [Project Intake](docs/planning/project-intake.md)
 - [Project Proposal](docs/planning/project-proposal.md)
+- [PRD](docs/planning/requirements-prd.md)
+- [Project Charter](docs/governance/project-charter.md)
+- [Project Roadmap](docs/planning/project-roadmap.md)
+- [Backlog and Milestones](docs/planning/backlog-milestones.md)
+
+### Architecture (M2)
+
+- [Options Analysis: Architecture Style](docs/architecture/options-analysis-architecture.md)
+- [Options Analysis: Protocol Strategy](docs/architecture/options-analysis-protocols.md)
+- ADRs 001–012 in [docs/architecture/adr/](docs/architecture/adr/)
+
+### Design (M3)
+
+- [System Design v0.1.3](docs/design/system-design.md)
+- [Module: Memory](docs/design/module-memory.md)
+- [Module: Retrieval](docs/design/module-retrieval.md)
+- [Module: Autonomy](docs/design/module-autonomy.md)
+- [Module: Infrastructure](docs/design/module-infrastructure.md)
+- [SLI/SLO Targets](docs/operations/sli-slo.md)
+- [Risk Register](docs/governance/risk-register.md)
+
+### Governance
+
 - [AGENTS.md](AGENTS.md) — AI agent behavior rules
 - [PLANS.md](PLANS.md) — ExecPlan requirements and progress
 

--- a/docs/architecture/options-analysis-architecture.md
+++ b/docs/architecture/options-analysis-architecture.md
@@ -14,6 +14,8 @@ tags: [architecture, options-analysis, 3ngram, monolith]
 
 # Options Analysis: Architecture Style
 
+> **Scope notice**: This analysis predates ADR-003 (Postgres+pgvector). Storage references reflect the evaluation context, not the accepted architecture. See system design v0.1.3 for current state.
+
 ## Purpose
 
 This document evaluates architecture style options for the 3ngram agentic

--- a/docs/architecture/options-analysis-protocols.md
+++ b/docs/architecture/options-analysis-protocols.md
@@ -12,6 +12,10 @@ extends: [STD-001, STD-021]
 tags: [architecture, options-analysis, 3ngram, mcp, a2a, protocols]
 ---
 
+# Options Analysis: Protocol Strategy
+
+> **Scope notice**: This analysis predates ADR-003 (Postgres+pgvector). Storage references reflect the evaluation context, not the accepted architecture. See system design v0.1.3 for current state.
+
 # Purpose
 
 Evaluate protocol integration strategies for exposing 3ngram's memory


### PR DESCRIPTION
## Summary

- Add ADR-003 scope notice blockquotes to both M2 options analyses (#7)
- Update README for M3 completion: 8 memory types, architecture overview with ADR links, full documentation index by milestone, status reflecting Stage 3 next (#4)

## Changes

**Issue #7 — Scope disclaimers** (trivial):
- `docs/architecture/options-analysis-architecture.md`: Added blockquote noting storage references predate ADR-003
- `docs/architecture/options-analysis-protocols.md`: Same disclaimer

**Issue #4 — README update** (small):
- Status section: M1–M3 complete, M4 (Specification) next
- Architecture overview: 8 memory types (was 4), links to key ADRs, Postgres+pgvector, self-healing
- Documentation section: organized by milestone (Planning, Architecture, Design, Governance) with links to all key artifacts
- Quick start: updated to reference specification phase

## KB standards consulted

- STD-001 (Documentation Standard)
- STD-021 (Architecture Standard)

## AI assistance

All edits authored by Claude Opus 4.6 per issue specifications. Pre-commit hooks pass (markdownlint, trailing whitespace, end-of-file).

## Test plan

- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Verify all documentation links resolve correctly
- [ ] Confirm scope disclaimers match Issue #7 specification

Closes #4, closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)