### PR TITLE
docs(governance): session 7 phase transition — design to specification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,9 @@ artifacts.
 
 ## Project-specific rules
 
-- This is a Tier 3 project in design phase. Do not write implementation
-  code until all design artifacts are approved.
+- This is a Tier 3 project in specification phase (Stage 3). Do not
+  write implementation code until technical specs and schema definitions
+  are approved.
 - Python package name is `engram` (not `3ngram`).
 - All design documents must follow KB templates from
   policies-and-standards.

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -7,8 +7,8 @@ the [ai_context_pack_tpl](https://github.com/sh4i-yurei/policies-and-standards/b
 
 - **What**: Agentic RAG memory system — kernel-governed memory OS for AI agents.
 - **Package**: `engram` (Python 3.12)
-- **Current milestone**: M3 — System design, threat model, SLI/SLO, risk register.
-- **Phase**: Design (pre-implementation). No code until all design artifacts are approved (STD-020).
+- **Current milestone**: M3 complete. Entering Stage 3 (Specification).
+- **Phase**: Specification (pre-implementation). No code until specs approved (STD-020).
 
 ## Governing standards
 
@@ -29,30 +29,27 @@ gh api repos/sh4i-yurei/policies-and-standards/contents/<path> --jq '.content' |
 | STD-008 | Testing and Quality | `03_Engineering_Standards/Testing_and_Quality_Standard.md` |
 | STD-056 | KB Integration | `03_Engineering_Standards/KB_Integration_Standard.md` |
 
-### Current phase (design)
-
-| ID | Standard | Path |
-|----|----------|------|
-| STD-021 | System Design Standard | `04_Design_Framework/System_Design_Standard.md` |
-| STD-022 | Module Design Standard | `04_Design_Framework/Module_Design_Standard.md` |
-| STD-024 | Design Review Checklist | `04_Design_Framework/Design_Review_Checklist.md` |
-| STD-055 | Schema Definition Standard | `04_Design_Framework/schema-definition-standard.md` |
-| STD-007 | Security and Threat Modeling | `03_Engineering_Standards/Security_and_Threat_Modeling_Standard.md` |
-| STD-043 | SLI/SLO Standard | `03_Engineering_Standards/SLI_SLO_Standard.md` |
-| STD-044 | Data Management Standard | `03_Engineering_Standards/Data_Management_Standard.md` |
-| STD-047 | Architecture Decision Workflow | `05_Dev_Workflows/architecture-decision-workflow.md` |
-| STD-034 | Design Review Workflow | `05_Dev_Workflows/design_review_workflow.md` |
-
-### Next phase (specification)
+### Current phase (specification)
 
 | ID | Standard | Path |
 |----|----------|------|
 | STD-023 | Technical Specification Standard | `04_Design_Framework/Technical_Specification_Standard.md` |
 | STD-055 | Schema Definition Standard | `04_Design_Framework/schema-definition-standard.md` |
+| STD-024 | Design Review Checklist | `04_Design_Framework/Design_Review_Checklist.md` |
+| STD-033 | Documentation Change Workflow | `05_Dev_Workflows/documentation_change_workflow.md` |
+| STD-034 | Design Review Workflow | `05_Dev_Workflows/design_review_workflow.md` |
+
+### Next phase (implementation)
+
+| ID | Standard | Path |
+|----|----------|------|
+| STD-005 | Coding Standards and Conventions | `03_Engineering_Standards/Coding_Standards_and_Conventions.md` |
+| STD-008 | Testing and Quality | `03_Engineering_Standards/Testing_and_Quality_Standard.md` |
+| STD-030 | CI/CD Pipeline Model | `05_Dev_Workflows/cicd_pipeline.md` |
 
 ## Rule packs (STD-048)
 
-Load these when starting implementation work. During design phase,
+Load these when starting implementation work. During specification phase,
 reference them for interface and data model decisions.
 
 | ID | Pack | Path | Applies because |

--- a/PLANS.md
+++ b/PLANS.md
@@ -23,10 +23,10 @@ Store ExecPlans under `plans/exec_plans/<YYYY-MM-DD>_<short_slug>.md`.
 
 ## Current status
 
-**Phase**: Design (pre-implementation)
-**Current milestone**: M3 (System Design) — complete
-**Last session**: Session 6 — Critical review, cross-artifact fixes, charter v0.2.1, design review PASS
-**Next**: Session 7 — PR to main, specification phase prep
+**Phase**: Specification (pre-implementation)
+**Current milestone**: M4 (Specification) — in progress
+**Last session**: Session 7 — Phase transition, governance updates, open issue triage
+**Next**: Session 8 — Technical specifications and schema definitions (Stage 3)
 
 ### Completed artifacts
 
@@ -63,6 +63,16 @@ Store ExecPlans under `plans/exec_plans/<YYYY-MM-DD>_<short_slug>.md`.
 
 - Technical Specification (docs/specs/technical-specification.md) — Stage 3
 - Schema Definitions (docs/design/schemas/) — Stage 3
+
+### Key decisions (Session 7)
+
+- **PR #3 merged**: M2 architecture decisions + M3 design artifacts merged to main (squash, commit 7b9854c). Design phase complete.
+- **Phase transition**: Design (Stage 2) complete, entering Specification (Stage 3). Governance files updated (PLANS.md, AI_CONTEXT.md, AGENTS.md).
+- **Spec phase scope**: Stage 3 requires ~4 technical specifications (one per module: Memory, Retrieval, Autonomy, Infrastructure) per STD-023, and ~7 schema definitions (memory_records, memory_versions, memory_edges, librarian_audit, librarian_queue, agent_registry, outbox) per STD-055.
+- **Authoring order**: Schema definitions first (tech specs reference them), then tech specs per module.
+- **ExecPlan required**: Stage 3 work is Tier 3 and needs an ExecPlan in `plans/exec_plans/` before starting.
+- **Open issues addressed**: #5 (CI gates), #7 (scope disclaimers) worked in parallel by separate instances.
+- **Parallel execution**: 3 Claude instances — Instance 1 (governance + orchestration), Instance 2 (docs issues #4/#7), Instance 3 (CI gates #5).
 
 ### Key decisions (Session 6)
 


### PR DESCRIPTION
## Summary

- Update PLANS.md with Session 7 state, key decisions, and Stage 3 scope
- Transition AI_CONTEXT.md phase tables from design → specification
- Update AGENTS.md phase reference to specification (Stage 3)

## Changes

| File | Change |
|------|--------|
| `PLANS.md` | Session 7 key decisions, phase/milestone/next updated |
| `AI_CONTEXT.md` | Current phase → specification (STD-023, STD-055, STD-024, STD-033, STD-034); next phase → implementation (STD-005, STD-008, STD-030) |
| `AGENTS.md` | Phase reference: "design phase" → "specification phase (Stage 3)" |

## KB citations

- STD-020 (Design-First Development Model) — design gate cleared
- STD-023 (Technical Specification Standard) — next artifact type
- STD-032 (SDLC with AI) — phase transition workflow
- STD-055 (Schema Definition Standard) — next artifact type
- STD-056 (KB Integration Standard) — governance file maintenance

## Test plan

- [x] `pre-commit run --all-files` passes (all 8 hooks)
- [x] No file overlap with parallel Instance 2 (#4/#7) or Instance 3 (#5) work

## AI assistance

All changes authored by Claude Opus 4.6. Phase transition scope determined
from approved system design v0.1.3 and KB standards STD-023/STD-055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)