### PR TITLE
fix(docs): repair broken links and add yamllint config

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,11 @@
+# yamllint configuration for 3ngram
+# Relaxes line-length to accommodate long YAML values (e.g., pre-commit
+# hook entries with inline bash commands).
+
+extends: default
+
+rules:
+  line-length:
+    max: 120
+  truthy:
+    check-keys: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,7 +56,7 @@ List supported releases or branches and how long they receive fixes.
 
 #### Safe behavior expectations
 
-- Follow [Security_and_Threat_Modeling_Standard](../../../03_Engineering_Standards/Security_and_Threat_Modeling_Standard.md).
+- Follow [Security_and_Threat_Modeling_Standard](https://github.com/sh4i-yurei/policies-and-standards/blob/main/03_Engineering_Standards/Security_and_Threat_Modeling_Standard.md).
 - Avoid new dependencies or services without approval.
 - Require code review and CI for all changes.
 
@@ -67,7 +67,7 @@ Security contact: <name/email/handle>.
 # Implementation Notes
 
 - Align vulnerability handling with
-  [vulnerability-management-workflow](../../../05_Dev_Workflows/vulnerability-management-workflow.md).
+  [vulnerability-management-workflow](https://github.com/sh4i-yurei/policies-and-standards/blob/main/05_Dev_Workflows/vulnerability-management-workflow.md).
 - Keep contact details current.
 
 # Continuous Improvement and Compliance Metrics

--- a/docs/governance/project-charter.md
+++ b/docs/governance/project-charter.md
@@ -317,9 +317,9 @@ This is the foundation every agentic system needs but doesn't have.
 
 **Project Artifacts:**
 
-- Intake: [docs/planning/project-intake.md](/home/mark/3ngram/docs/planning/project-intake.md)
-- Proposal: [docs/planning/project-proposal.md](/home/mark/3ngram/docs/planning/project-proposal.md)
-- Charter: [docs/governance/project-charter.md](/home/mark/3ngram/docs/governance/project-charter.md) (this document)
+- Intake: [docs/planning/project-intake.md](../planning/project-intake.md)
+- Proposal: [docs/planning/project-proposal.md](../planning/project-proposal.md)
+- Charter: [docs/governance/project-charter.md](project-charter.md) (this document)
 - PRD: `docs/planning/prd.md` (next)
 - Roadmap: `docs/planning/roadmap.md` (next)
 

--- a/docs/planning/project-proposal.md
+++ b/docs/planning/project-proposal.md
@@ -177,11 +177,11 @@ Per Tier 3 ceremony (STD-032):
 - [x] ADRs (001-006): [docs/architecture/adr/](../architecture/adr/)
 - [ ] System design: [system-design.md](../design/system-design.md)
 - [ ] Module designs: docs/design/module-*.md
-- [ ] Threat model: [threat-model.md](../operations/threat-model.md)
+- [ ] Threat model: `docs/operations/threat-model.md` (pending)
 - [ ] SLI/SLO targets: [sli-slo.md](../operations/sli-slo.md)
 - [ ] Risk register: [risk-register.md](../governance/risk-register.md)
 - [ ] Technical specification: [technical-specification.md](../specs/technical-specification.md)
-- [ ] Schema definitions: [docs/design/schemas/](../design/schemas/)
+- [ ] Schema definitions: `docs/design/schemas/` (pending)
 - [ ] Design review (red-team pass)
 
 ### Risks and dependencies

--- a/docs/specs/technical-specification.md
+++ b/docs/specs/technical-specification.md
@@ -15,7 +15,7 @@ tags: [template, specification, implementation]
 # Purpose
 
 Provide a structured Technical Specification template aligned to
-[Technical_Specification_Standard](../../../04_Design_Framework/Technical_Specification_Standard.md). Use this to authorize and
+[Technical_Specification_Standard](https://github.com/sh4i-yurei/policies-and-standards/blob/main/04_Design_Framework/Technical_Specification_Standard.md). Use this to authorize and
 constrain implementation work.
 
 # Scope
@@ -27,7 +27,7 @@ Use for any change that modifies code or system behavior.
 ## Technical specification template
 
 Translate an approved Module Design into explicit implementation
-instructions. Follow [Technical_Specification_Standard](../../../04_Design_Framework/Technical_Specification_Standard.md).
+instructions. Follow [Technical_Specification_Standard](https://github.com/sh4i-yurei/policies-and-standards/blob/main/04_Design_Framework/Technical_Specification_Standard.md).
 
 ## Scope and intent
 
@@ -51,7 +51,7 @@ Describe data models, schemas, migrations, and ownership changes.
 ## Schema definitions
 
 Link schema definition artifacts and canonical schema files (API
-schemas, data models, event formats) per [schema-definition-standard](../../../04_Design_Framework/schema-definition-standard.md).
+schemas, data models, event formats) per [schema-definition-standard](https://github.com/sh4i-yurei/policies-and-standards/blob/main/04_Design_Framework/schema-definition-standard.md).
 
 ## Algorithms and control flow
 


### PR DESCRIPTION
## Summary

Fix all Gate B (link-check) and Gate E (yamllint) failures caused by pre-existing issues in M1-M3 docs. Unblocks PR #12 (CI gates) after merge + rebase.

## Changes

### Issue #13 — Broken links (4 files, 9 links)

**KB-relative paths → GitHub URLs:**
- `SECURITY.md`: 2 links to `policies-and-standards` docs converted from `../../../` relative paths to full GitHub URLs
- `docs/specs/technical-specification.md`: 3 links to KB design framework docs converted the same way

**Future-phase artifacts (don't exist yet):**
- `docs/planning/project-proposal.md`: 2 links to `threat-model.md` and `schemas/` replaced with backtick code references marked `(pending)` — these files will be created in Stage 3

**Absolute local paths → relative paths:**
- `docs/governance/project-charter.md`: 3 links using `/home/mark/3ngram/...` converted to proper relative paths (`../planning/...`, `project-charter.md`)

### Issue #14 — yamllint line-length

- Added `.yamllint.yaml` at repo root with `line-length: max: 120` and `truthy: check-keys: false`
- Fixes Gate E failure on `.pre-commit-config.yaml` line 23 (116 chars)

## Files NOT touched

- `.github/workflows/` — owned by PR #12
- `.github/mlc_config.json` — owned by PR #12
- `tests/` — owned by PR #12

## KB standards consulted

- STD-001 (Documentation Standard)
- STD-030 (CI/CD Pipeline Model)

## AI assistance

All edits authored by Claude Opus 4.6 per issue specifications. Pre-commit hooks pass.

## Test plan

- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] All relative link targets verified to exist
- [x] Future-phase files confirmed absent (correctly unlinked)
- [ ] Gate B link-check passes after merge (verified by CI on PR #12 rebase)
- [ ] Gate E yamllint passes after merge

Closes #13, closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)