### PR TITLE
fix(docs): repair remaining broken links and shorten pre-commit entry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: markdownlint-cli2
         name: markdownlint-cli2
-        entry: bash -c 'export PATH="/home/mark/.nvm/versions/node/v24.11.0/bin:$PATH" && markdownlint-cli2 "$@"' --
+        entry: scripts/markdownlint.sh
         language: system
         types: [markdown]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ assistance.
 
 #### Coding and testing expectations
 
-- Follow [Coding_Standards_and_Conventions](../../../03_Engineering_Standards/Coding_Standards_and_Conventions.md) and
-  [Testing_and_Quality_Standard](../../../03_Engineering_Standards/Testing_and_Quality_Standard.md).
+- Follow [Coding_Standards_and_Conventions](https://github.com/sh4i-yurei/policies-and-standards/blob/main/03_Engineering_Standards/Coding_Standards_and_Conventions.md) and
+  [Testing_and_Quality_Standard](https://github.com/sh4i-yurei/policies-and-standards/blob/main/03_Engineering_Standards/Testing_and_Quality_Standard.md).
 - Write or update tests with each change; no failing tests on merge.
 
 #### Documentation expectations
@@ -59,7 +59,7 @@ assistance.
 #### AI-assisted work
 
 - Provide the approved spec and standards in the prompt context.
-- Follow [KB_Integration_Standard](../../../03_Engineering_Standards/KB_Integration_Standard.md) and `AGENTS.md` for KB retrieval and
+- Follow [KB_Integration_Standard](https://github.com/sh4i-yurei/policies-and-standards/blob/main/03_Engineering_Standards/KB_Integration_Standard.md) and `AGENTS.md` for KB retrieval and
   pointer artifact requirements.
 - Summarize AI-generated changes in the PR description.
 - Do not bypass reviews or required gates.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -19,13 +19,13 @@ Document how this project validates behavior.
 # Scope
 
 Use for project-specific testing expectations aligned to
-[Testing_and_Quality_Standard](../../../03_Engineering_Standards/Testing_and_Quality_Standard.md).
+[Testing_and_Quality_Standard](https://github.com/sh4i-yurei/policies-and-standards/blob/main/03_Engineering_Standards/Testing_and_Quality_Standard.md).
 
 # Standard
 
 ## Testing strategy template
 
-Align with [Testing_and_Quality_Standard](../../../03_Engineering_Standards/Testing_and_Quality_Standard.md) and project requirements.
+Align with [Testing_and_Quality_Standard](https://github.com/sh4i-yurei/policies-and-standards/blob/main/03_Engineering_Standards/Testing_and_Quality_Standard.md) and project requirements.
 
 ## Test strategy
 

--- a/scripts/markdownlint.sh
+++ b/scripts/markdownlint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Wrapper for markdownlint-cli2 using system-installed node.
+# Used by pre-commit to avoid nvm lazy-load issues.
+set -euo pipefail
+export PATH="/home/mark/.nvm/versions/node/v24.11.0/bin:$PATH"
+exec markdownlint-cli2 "$@"


### PR DESCRIPTION
## Summary

Round 2 of Issue #13 fixes. PR #15 caught most broken links but missed
CONTRIBUTING.md and docs/TESTING.md. Also restructures the pre-commit
markdownlint entry to get under yamllint's 80-char line-length threshold.

## Changes

### Broken links (5 remaining KB-relative paths → GitHub URLs)

**CONTRIBUTING.md** (3 links):
- Line 49: `Coding_Standards_and_Conventions` → GitHub URL
- Line 50: `Testing_and_Quality_Standard` → GitHub URL
- Line 62: `KB_Integration_Standard` → GitHub URL

**docs/TESTING.md** (2 links):
- Line 22: `Testing_and_Quality_Standard` → GitHub URL
- Line 28: Same link (repeated) → GitHub URL

### Pre-commit line-length (Gate E)

- Extracted inline bash command from `.pre-commit-config.yaml` line 23
  (was 116 chars) into `scripts/markdownlint.sh` wrapper script
- Entry is now `entry: scripts/markdownlint.sh` — longest line is 72 chars
- Script handles nvm PATH setup and exec's markdownlint-cli2

## KB standards consulted

- STD-001 (Documentation Standard)
- STD-030 (CI/CD Pipeline Model)

## AI assistance

All edits authored by Claude Opus 4.6. Pre-commit hooks pass.

## Test plan

- [x] Pre-commit hooks pass (markdownlint-cli2 works via new wrapper)
- [x] Longest .pre-commit-config.yaml line is 72 chars (< 80)
- [ ] Gate B link-check passes after merge (verified on PR #12 rebase)
- [ ] Gate E yamllint passes after merge

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)