### PR TITLE
chore(skills): add M4 agent skills for spec, schema, and architecture

### DIFF
--- a/.claude/skills/architecture-knowledge/SKILL.md
+++ b/.claude/skills/architecture-knowledge/SKILL.md
@@ -13,8 +13,8 @@ Consult this before proposing any architectural change.
 
 ## ADR Index
 
-All ADRs live in `docs/architecture/adr/`. Every ADR status is
-**Accepted**.
+All ADRs live in `docs/architecture/adr/`. Every numbered ADR listed
+below (ADR-001 through ADR-012) currently has status **Accepted**.
 
 | ADR | Title | Supersedes | Phase |
 |-----|-------|------------|-------|
@@ -46,6 +46,19 @@ domain layer.
 **ADR-003 Storage backend**: Postgres+pgvector replaces Postgres+Qdrant.
 Unified storage eliminates cross-database consistency bugs. HNSW
 indexing, hybrid search via RRF in SQL. Scaling ceiling ~1M vectors.
+
+**ADR-004 Embedding model** (superseded by ADR-007): Selected fastembed
+with BAAI/bge-small-en-v1.5 (384 dims). CPU-first, GPU optional via
+RTX 3070. ONNX Runtime avoids PyTorch dependency.
+
+**ADR-005 Agent roles** (superseded by ADR-008): Agent roles as Python
+Protocol classes (Researcher for MVP). No framework dependency
+(LangGraph, CrewAI avoided). AgentRole Protocol with `execute()`,
+`cancel()`, `health_check()`.
+
+**ADR-006 Knowledge graph** (superseded by ADR-009): Lightweight
+`memory_edges` table designed but implementation deferred to post-MVP.
+Edge types: supersedes, supports, contradicts, relates_to, derived_from.
 
 **ADR-007 Embedding adapter**: EmbeddingAdapter Protocol
 (`embed_one`, `embed_batch`, `dimension`, `model_name`). fastembed
@@ -154,7 +167,7 @@ classification, confidence calibration) -- heuristic Phase 1, RL Phase
 | Module: Memory | `docs/design/module-memory.md` |
 | Module: Retrieval | `docs/design/module-retrieval.md` |
 | Module: Autonomy | `docs/design/module-autonomy.md` |
-| Module: Infrastructure | `docs/design/module-infrastructure.md` (pending) |
+| Module: Infrastructure | `docs/design/module-infrastructure.md` |
 | ADRs (12) | `docs/architecture/adr/ADR-{001..012}-*.md` |
 | Options Analyses | `docs/architecture/options-analysis-*.md` |
 | PRD | `docs/planning/requirements-prd.md` |
@@ -163,7 +176,7 @@ classification, confidence calibration) -- heuristic Phase 1, RL Phase
 | SLI/SLO | `docs/operations/sli-slo.md` |
 | Risk Register | `docs/governance/risk-register.md` |
 | Schemas | `docs/design/schemas/` (pending) |
-| Specs | `docs/specs/` (pending) |
+| Specs | `docs/specs/` (template exists; project specs pending) |
 
 ## Key interfaces
 

--- a/.claude/skills/spec-authoring/SKILL.md
+++ b/.claude/skills/spec-authoring/SKILL.md
@@ -60,10 +60,13 @@ Every spec MUST include all 10 sections. Empty sections must state
 
 ## Template reference (TPL-PRJ-TECH-SPEC)
 
-The canonical template lives in the KB at:
+This repo has a local copy of the template at:
+`docs/specs/technical-specification.md`
+
+The upstream KB version lives at:
 `06_Projects/Templates/design/technical_specification_tpl.md`
 
-Fetch it with:
+To refresh from the upstream KB (e.g., to sync with central standards):
 
 ```bash
 gh api repos/sh4i-yurei/policies-and-standards/contents/06_Projects/Templates/design/technical_specification_tpl.md --jq '.content' | base64 -d
@@ -82,7 +85,7 @@ Before requesting review, verify:
 - [ ] Non-functional constraints have measurable targets
 - [ ] Exclusions section prevents scope creep
 - [ ] No implementation code in the spec (pseudocode is acceptable)
-- [ ] Frontmatter includes: title, version, status, owner, last_updated
+- [ ] Frontmatter includes: id, title, category, version, status, owner, reviewer, approver, extends, tags, last_updated
 
 ## 3ngram-specific guidance
 


### PR DESCRIPTION
## Summary

Add three project-level agent skills for Stage 3 (Specification) work:

- **spec-authoring**: Technical specification writing per STD-023 with 10 required sections, traceability chain (PRD → System Design → Module Design → Spec), and pre-submission checklist
- **schema-authoring**: Schema definitions per STD-055 with 3ngram-specific memory record base fields, bi-temporal versioning guidance, and format progression (prose → JSON Schema → SQL DDL → Pydantic)
- **architecture-knowledge**: Complete ADR index (all 12 decisions), module boundary table, 5 settled decisions, 5 key invariants, design document location map, and write/read path summaries

## KB references

- STD-023: Technical Specification Standard (spec-authoring)
- STD-055: Schema Definition Standard (schema-authoring)
- STD-058: Agent Skills Standard (skill format)
- STD-020: Design-First Development Model (traceability)
- STD-047: Architecture Decision Workflow (ADR governance)
- TPL-PRJ-TECH-SPEC: Technical specification template
- TPL-PRJ-SCHEMA: Schema definition template

## Test plan

- [ ] Verify all 3 skill files pass markdownlint
- [ ] Verify YAML frontmatter has `name` and `description` fields
- [ ] Verify spec-authoring covers all 10 STD-023 sections
- [ ] Verify schema-authoring includes all 6 key tables from system design
- [ ] Verify architecture-knowledge summarizes all 12 ADRs
- [ ] Verify pre-commit passes

## AI assistance summary

All skill content authored by Claude Code (Instance 2, Session 8) based on:
- Direct reading of all 12 ADR files in `docs/architecture/adr/`
- Direct reading of system design at `docs/design/system-design.md`
- KB templates fetched from policies-and-standards repo

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)